### PR TITLE
ENOENT: no such file or directory ./temp/raw/... in "fileBuffer" mode (as opposed to "filePath" mode)

### DIFF
--- a/lib/build/Lame.js
+++ b/lib/build/Lame.js
@@ -288,7 +288,8 @@ class Lame {
      * @returns {string} Path
      */
     tempFilePathGenerator(type, progressType) {
-        let path = `./temp/${type}/`;
+        let prefix = __dirname + `/../.`;
+        let path = prefix + `./temp/${type}/`;
         let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         for (let i = 0; i < 32; i++) {
             path += possible.charAt(Math.floor(Math.random() * possible.length));
@@ -296,7 +297,7 @@ class Lame {
         if (type == "raw" && progressType == "decode") {
             path += `.mp3`;
         }
-        if (!fs_1.existsSync(`./temp/${path}`)) {
+        if (!fs_1.existsSync(prefix + `./temp/${path}`)) {
             return path;
         }
         else {


### PR DESCRIPTION
*reproduced bug evoked in #1, fix proposal*

Creating a `test-dbg.js` in `node-lame/test/` (see below for `test-dbg.js` content) and running 

> `node test-dbg.js`

**from the test folder** results in:

```
$ NODE_DEBUG=fs node dbg-tmp-path.js
fs.js:94
        throw backtrace;
        ^

Error: ENOENT: no such file or directory, unlink './temp/raw/1jToI7sLifXwqsccSzIv6bHTrtxVhpNa'
    at rethrow (fs.js:89:21)
    at makeCallback (fs.js:115:12)
    at Object.fs.unlink (fs.js:1080:14)
    at Lame.removeTempFilesOnError (/Users/.../node-lame/lib/build/Lame.js:312:22)
    at Promise.then.catch (/Users/.../node-lame/lib/build/Lame.js:138:22)
```

test-dbg content:
```
const INFILEPATH = "./example.wav";
const OUTFILEPATH = "./todelete.mp3";

const Lame = require("../index").Lame;
const fsp = require("fs-promise");

fsp.readFile(INFILEPATH)
  .then((inputBuffer) => {

    const instance = new Lame({
      "output": OUTFILEPATH,
      "bitrate": 128
    })

    instance.setBuffer(inputBuffer);
    instance.encode().then(() => { console.log('encoding over') });

  });
```






