### PR TITLE
Add artwork to meta types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ declare namespace Options {
         comment?: string;
         track?: string;
         genre?: string;
+        artwork?: string;
 
         "add-id3v2"?: boolean;
         "id3v1-only"?: boolean;


### PR DESCRIPTION
Supported here: https://github.com/devowlio/node-lame/blob/b61cb830c2573404d437eb552c07bbe11bd0fcf8/lib/src/LameOptions.ts#L602
Not present in TS typings.